### PR TITLE
Fixes issue with mkdirp in Windows

### DIFF
--- a/lib/ImagePackager.js
+++ b/lib/ImagePackager.js
@@ -1,7 +1,6 @@
 // Node requires
-const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
+const fs = require('fs-extra');
 
 // Parcel requires
 const parcelRequires = require('./parcelRequires');
@@ -20,7 +19,7 @@ class ImagePackager extends RawPackager {
       contents = Buffer.from(contents.data);
     }
 
-    await mkdirp(path.dirname(name));
+    await fs.ensureDir(path.dirname(name));
     
     await new Promise((resolve, reject) => {
       fs.writeFile(name, contents, (err) => {

--- a/lib/ImagePackager.js
+++ b/lib/ImagePackager.js
@@ -1,5 +1,4 @@
 // Node requires
-const path = require('path');
 const fs = require('fs-extra');
 
 // Parcel requires
@@ -19,18 +18,7 @@ class ImagePackager extends RawPackager {
       contents = Buffer.from(contents.data);
     }
 
-    await fs.ensureDir(path.dirname(name));
-    
-    await new Promise((resolve, reject) => {
-      fs.writeFile(name, contents, (err) => {
-        if (err) {
-          console.log("Tried writing to", name)
-          console.error(err)
-          return reject(err);
-        }
-        return resolve();
-      });
-    });
+    await fs.outputFile(name, contents)
 
     this.size = contents.length ? contents.length : 0;
   }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
     "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.1.0",
     "parcel-bundler": "^1.5.0",
-    "mkdirp": "^0.5.1"
+    "fs-extra": "^7.0.0"
   },
   "devDependencies": {
-    "fs-extra": "^7.0.0",
     "mocha": "^5.1.1",
     "parcel-assert-bundle-tree": "^1.0.0"
   }


### PR DESCRIPTION
Not sure why there was a ENOENT error :S Parcel uses mkdirp as well.

Replaced `mkdirp` with `fs-extra`