### PR TITLE
parcel@v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "imagemin-pngquant": "^8.0.0",
     "imagemin-svgo": "^7.0.0",
     "imagemin-webp": "^5.1.0",
-    "parcel-bundler": "^1.10.3"
+    "parcel": "^1.10.3"
   },
   "devDependencies": {
     "husky": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "imagemin-pngquant": "^8.0.0",
     "imagemin-svgo": "^7.0.0",
     "imagemin-webp": "^5.1.0",
-    "parcel": "^1.10.3"
+    "parcel": "^1.10.3 || 2.0.0-alpha.1.1"
   },
   "devDependencies": {
     "husky": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "imagemin-pngquant": "^8.0.0",
     "imagemin-svgo": "^7.0.0",
     "imagemin-webp": "^5.1.0",
-    "parcel": "^1.10.3 || 2.0.0-alpha.1.1"
+    "parcel": "^1.10.3 || ^2.0.0-alpha.1.1"
   },
   "devDependencies": {
     "husky": "^3.0.5",


### PR DESCRIPTION
Maintains backwards compatibility with v1 (not 100%, using parcel instead of parcel-bundler)